### PR TITLE
Restart sync polling if the process crashes

### DIFF
--- a/lib/vagrant-unison2/shell_command.rb
+++ b/lib/vagrant-unison2/shell_command.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
       private
 
       def args
-        [
+        _args = [
           'unison',
           @paths.host,
           @ssh_command.uri,
@@ -33,6 +33,7 @@ module VagrantPlugins
           ignore_arg,
           ['-sshargs', %("#{@ssh_command.command}")],
         ].flatten.compact
+        _args
       end
 
       def batch_arg

--- a/lib/vagrant-unison2/version.rb
+++ b/lib/vagrant-unison2/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Unison
-    VERSION = "1.0.3"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
There seems to be a memory leak in unison, so after a while it fails. Now, unison will restart if it crashes or gets a ctrl+c, kill it by pressing ctrl+c twice.
