### PR TITLE
Add a background thread to kill vagrant when memory use gets high

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,20 @@ end
 ```
 1. Start up your starting your vagrant box as normal (eg: `vagrant up`)
 
+
 ## Start syncing Folders
 
 Run `vagrant unison-sync-once` to run a single, non-interactive sync and then exit.
 
+Run `vagrant unison-sync-polling` to start in bidirect monitor (repeat) mode - every second unison checks for changes on either side and syncs them.
+
+## (Legacy) Sync using OSX inotify events
+
 Run `vagrant unison-sync` to sync then start watching the local_folder for changes, and syncing these to your vagrang VM.
 
-Under the covers this uses your system installation of [Unison](http://www.cis.upenn.edu/~bcpierce/unison/), 
-which must be installed in your path.
+This uses the `watch` ruby gem and runs a one-off unison sync when it gets change events.
 
-## Start syncing Folders with polling (unison repeat mode)
-
-Run `vagrant unison-sync-polling` to start in bidirect monitor (repeat) mode - every second unison checks for changes on either side and syncs them.
+For some reason, this does not always get all the events immediately which can be frustrating. Since the polling mode (unison repeat mode) is not too resource intensive, I recommend that instead.
 
 ## Sync in interactive mode
 
@@ -56,6 +58,12 @@ This is a useful tool when the automatic sync sees a change in a file on both
 sides and skips it.
 
 ## Cleanup unison database
+Run `vagrant unison-cleanup` to clear the unison metadata from `~/Library/Application Support/Unison/` as well as all files.
+
+## Error states
+
+### Inconsistent state with unison metadata
+
 When you get
 ```
 Fatal error: Warning: inconsistent state.  
@@ -67,8 +75,22 @@ Please delete archive files as appropriate and try again
 or invoke Unison with -ignorearchives flag.
 ```
 
-Run `vagrant unison-cleanup` to clear Archive from ~/Library/Application Support/Unison/ and files from host folder.
+You should run a unison-cleanup
+
 Running Unison with -ignorearchives flag is a bad idea, since it will produce conflicts.
+
+### Skipping files changed on both sides
+
+This is most often caused in my experience by files that get changed by different users with different permissions.
+
+For instance, if you're running an Ubuntu VM then the unison process is running
+as the vagrant user. If you have the unison synced folder loaded as a volume in
+a docker container and a new file gets created in the container, the vagrant
+user in the VM won't own that file and this can keep unison from being able to
+sync the file. (I'm looking for a way to fix this particular error case).
+
+Running a unison-cleanup should fix this state.
+
 
 ## Development
 

--- a/lib/vagrant-unison2/command.rb
+++ b/lib/vagrant-unison2/command.rb
@@ -110,7 +110,7 @@ module VagrantPlugins
             command.terse = true
             command = command.to_s
 
-            # @env.ui.info "Running #{command}"
+            @env.ui.info "Running #{command}"
 
             # Re-run on a crash.
             # On a sigint, wait 2 seconds before respawning command.
@@ -144,7 +144,7 @@ module VagrantPlugins
         unison_mem_cap_mb = 100
         Thread.new(ssh_command.ssh, unison_mem_cap_mb) do |ssh_command_text, mem_cap_mb|
           while true
-            sleep 2
+            sleep 15
             total_mem = `#{ssh_command_text} 'free -m | egrep "^Mem:" | awk "{print \\$2}"' 2>/dev/null`
             _unison_proc_returnval = `#{ssh_command_text} 'ps aux | grep "[u]nison -server" | awk "{print \\$2, \\$4}"' 2>/dev/null`
             if _unison_proc_returnval == ''

--- a/lib/vagrant-unison2/command.rb
+++ b/lib/vagrant-unison2/command.rb
@@ -142,21 +142,21 @@ module VagrantPlugins
       def watch_vm_for_memory_leak(machine)
         ssh_command = SshCommand.new(machine)
         unison_mem_cap_mb = 50
-        Thread.new(ssh_command.command, unison_mem_cap_mb) do |ssh_command_text, mem_cap_mb|
+        Thread.new(ssh_command.command2, unison_mem_cap_mb) do |ssh_command_text, mem_cap_mb|
           while true
-            sleep 30
-            total_mem = `ssh vagrant@127.0.0.1 #{ssh_command.command} 'free -m | egrep "^Mem:" | awk "{print \\$2}"' 2>/dev/null`
-            _unison_proc_returnval = `ssh vagrant@127.0.0.1 #{ssh_command.command} 'ps aux | grep "[u]nison -server" | awk "{print \\$2, \\$4}"' 2>/dev/null`
+            sleep 2
+            total_mem = `#{ssh_command_text} 'free -m | egrep "^Mem:" | awk "{print \\$2}"' 2>/dev/null`
+            _unison_proc_returnval = `#{ssh_command_text} 'ps aux | grep "[u]nison -server" | awk "{print \\$2, \\$4}"' 2>/dev/null`
             if _unison_proc_returnval == ''
               puts "Unison not running in VM"
               next
             end
             pid, mem_pct_unison = _unison_proc_returnval.strip.split(' ')
             mem_unison = (total_mem.to_f * mem_pct_unison.to_f/100).round(1)
-            # puts "Unison running as #{pid} using #{mem_unison} mb"
+            puts "Unison running as #{pid} using #{mem_unison} mb"
             if mem_unison > mem_cap_mb
               puts "Unison using #{mem_unison} mb memory is over limit of #{mem_cap_mb}, restarting"
-              `ssh vagrant@127.0.0.1 #{ssh_command.command} kill -HUP #{pid} 2>/dev/null`
+              `#{ssh_command_text} kill -HUP #{pid} 2>/dev/null`
             end
           end
         end

--- a/lib/vagrant-unison2/command.rb
+++ b/lib/vagrant-unison2/command.rb
@@ -141,8 +141,8 @@ module VagrantPlugins
 
       def watch_vm_for_memory_leak(machine)
         ssh_command = SshCommand.new(machine)
-        unison_mem_cap_mb = 50
-        Thread.new(ssh_command.command2, unison_mem_cap_mb) do |ssh_command_text, mem_cap_mb|
+        unison_mem_cap_mb = 100
+        Thread.new(ssh_command.ssh, unison_mem_cap_mb) do |ssh_command_text, mem_cap_mb|
           while true
             sleep 2
             total_mem = `#{ssh_command_text} 'free -m | egrep "^Mem:" | awk "{print \\$2}"' 2>/dev/null`
@@ -153,7 +153,8 @@ module VagrantPlugins
             end
             pid, mem_pct_unison = _unison_proc_returnval.strip.split(' ')
             mem_unison = (total_mem.to_f * mem_pct_unison.to_f/100).round(1)
-            puts "Unison running as #{pid} using #{mem_unison} mb"
+            # Debugging: uncomment to log every loop tick
+            # puts "Unison running as #{pid} using #{mem_unison} mb"
             if mem_unison > mem_cap_mb
               puts "Unison using #{mem_unison} mb memory is over limit of #{mem_cap_mb}, restarting"
               `#{ssh_command_text} kill -HUP #{pid} 2>/dev/null`

--- a/lib/vagrant-unison2/shell_command.rb
+++ b/lib/vagrant-unison2/shell_command.rb
@@ -1,9 +1,9 @@
 module VagrantPlugins
   module Unison
     class ShellCommand
-      def initialize machine, paths, ssh_command
+      def initialize machine, unison_paths, ssh_command
         @machine = machine
-        @paths = paths
+        @unison_paths = unison_paths
         @ssh_command = ssh_command
       end
 
@@ -25,8 +25,8 @@ module VagrantPlugins
       def args
         _args = [
           'unison',
-          @paths.host,
-          @ssh_command.uri,
+          @unison_paths.host,
+          @ssh_command.uri(@unison_paths),
           batch_arg,
           terse_arg,
           repeat_arg,

--- a/lib/vagrant-unison2/shell_command.rb
+++ b/lib/vagrant-unison2/shell_command.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
           terse_arg,
           repeat_arg,
           ignore_arg,
-          ['-sshargs', %("#{@ssh_command.command}")],
+          ['-sshargs', %("#{@ssh_command.ssh_args}")],
         ].flatten.compact
         _args
       end

--- a/lib/vagrant-unison2/ssh_command.rb
+++ b/lib/vagrant-unison2/ssh_command.rb
@@ -1,14 +1,13 @@
 module VagrantPlugins
   module Unison
     class SshCommand
-      def initialize(machine, unison_paths)
+      def initialize(machine)
         @machine = machine
-        @unison_paths = unison_paths
       end
 
       def command
         %W(
-          -p #{ssh_info[:port]}
+          -p #{@machine.ssh_info[:port]}
           #{proxy_command}
           -o StrictHostKeyChecking=no
           -o UserKnownHostsFile=/dev/null
@@ -16,27 +15,23 @@ module VagrantPlugins
         ).compact.join(' ')
       end
 
-      def uri
-        username = ssh_info[:username]
-        host = ssh_info[:host]
+      def uri(unison_paths)
+        username = @machine.ssh_info[:username]
+        host = @machine.ssh_info[:host]
 
-        "ssh://#{username}@#{host}/#{@unison_paths.guest}"
+        "ssh://#{username}@#{host}/#{unison_paths.guest}"
       end
 
       private
 
       def proxy_command
-        command = ssh_info[:proxy_command]
+        command = @machine.ssh_info[:proxy_command]
         return nil unless command
         "-o ProxyCommand='#{command}'"
       end
 
-      def ssh_info
-        @machine.ssh_info
-      end
-
       def key_paths
-        ssh_info[:private_key_path].map { |p| "-i #{p}" }.join(' ')
+        @machine.ssh_info[:private_key_path].map { |p| "-i #{p}" }.join(' ')
       end
     end
   end

--- a/lib/vagrant-unison2/ssh_command.rb
+++ b/lib/vagrant-unison2/ssh_command.rb
@@ -5,6 +5,14 @@ module VagrantPlugins
         @machine = machine
       end
 
+      def command2
+        %W(
+          ssh
+          vagrant@127.0.0.1
+          #{command}
+        ).compact.join(' ')
+      end
+
       def command
         %W(
           -p #{@machine.ssh_info[:port]}

--- a/lib/vagrant-unison2/ssh_command.rb
+++ b/lib/vagrant-unison2/ssh_command.rb
@@ -5,15 +5,15 @@ module VagrantPlugins
         @machine = machine
       end
 
-      def command2
+      def ssh
         %W(
           ssh
           vagrant@127.0.0.1
-          #{command}
+          #{ssh_args}
         ).compact.join(' ')
       end
 
-      def command
+      def ssh_args
         %W(
           -p #{@machine.ssh_info[:port]}
           #{proxy_command}

--- a/lib/vagrant-unison2/unison_sync.rb
+++ b/lib/vagrant-unison2/unison_sync.rb
@@ -12,7 +12,7 @@ module VagrantPlugins
         machine.communicate.sudo("mkdir -p '#{guest_path}'")
         machine.communicate.sudo("chown #{machine.ssh_info[:username]} '#{guest_path}'")
 
-        ssh_command = SshCommand.new(machine, unison_paths)
+        ssh_command = SshCommand.new(machine)
         shell_command = ShellCommand.new(machine, unison_paths, ssh_command)
 
         yield shell_command

--- a/lib/vagrant-unison2/version.rb
+++ b/lib/vagrant-unison2/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Unison
-    VERSION = "1.1.1"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/vagrant-unison2/version.rb
+++ b/lib/vagrant-unison2/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Unison
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end


### PR DESCRIPTION
Turns out there's a pretty severe memory leak in the VM with unison running.

This adds a background thread that checks how much memory unison is using in the VM every few seconds and restarts it if above the threshhold. Right now the threshold is somewhat arbitrarily chosen at 100mb, which ends up restarting unison every 10-20 min or so on my macbook pro.

Also updates the README with the recommended way of running.
