### PR TITLE
Make the Restart memory limit a config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ Vagrant.configure("2") do |config|
   config.unison.guest_folder = "src/" #relative to the vagrant home folder -> /home/vagrant
 
   # Optional configs
-  config.unison.ignore = "Name {.DS_Store,.git,node_modules}" # Ensure you don't have spaces between the commas!
-  config.unison.ssh_host = "10.0.0.1" # Default is '127.0.0.1'
-  config.unison.ssh_port = 22 # Default is 2222
-  config.unison.ssh_user = "deploy" # Default is 'vagrant'
+  # File patterns to ignore when syncing. Ensure you don't have spaces between the commas!
+  config.unison.ignore = "Name {.DS_Store,.git,node_modules}" # Default: none
+  # SSH connection details for Vagrant to communicate with VM.
+  config.unison.ssh_host = "10.0.0.1" # Default: '127.0.0.1'
+  config.unison.ssh_port = 22 # Default: 2222
+  config.unison.ssh_user = "deploy" # Default: 'vagrant'
+  # `vagrant unison-sync-polling` command will restart unison in VM if memory usage gets above this threshold (in MB).
+  config.unison.mem_cap_mb = 500 # Default: 200
 
 end
 ```

--- a/lib/vagrant-unison2/command.rb
+++ b/lib/vagrant-unison2/command.rb
@@ -141,8 +141,7 @@ module VagrantPlugins
 
       def watch_vm_for_memory_leak(machine)
         ssh_command = SshCommand.new(machine)
-        unison_mem_cap_mb = 100
-        Thread.new(ssh_command.ssh, unison_mem_cap_mb) do |ssh_command_text, mem_cap_mb|
+        Thread.new(ssh_command.ssh, machine.config.unison.mem_cap_mb) do |ssh_command_text, mem_cap_mb|
           while true
             sleep 15
             total_mem = `#{ssh_command_text} 'free -m | egrep "^Mem:" | awk "{print \\$2}"' 2>/dev/null`
@@ -156,7 +155,7 @@ module VagrantPlugins
             # Debugging: uncomment to log every loop tick
             # puts "Unison running as #{pid} using #{mem_unison} mb"
             if mem_unison > mem_cap_mb
-              puts "Unison using #{mem_unison} mb memory is over limit of #{mem_cap_mb}, restarting"
+              puts "Unison using #{mem_unison}MB memory is over limit of #{mem_cap_mb}MB, restarting"
               `#{ssh_command_text} kill -HUP #{pid} 2>/dev/null`
             end
           end

--- a/lib/vagrant-unison2/config.rb
+++ b/lib/vagrant-unison2/config.rb
@@ -38,27 +38,22 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :ssh_user
 
+      # Memory usage cap in MB
+      # Restart Unison in the VM when it's consuming more than this
+      # amount of memory (in MB)
+      # @return [int]
+      attr_accessor :mem_cap_mb
+
       def initialize(region_specific=false)
         @host_folder   = UNSET_VALUE
-        @remote_folder = UNSET_VALUE
+        @guest_folder  = UNSET_VALUE
         @ignore        = UNSET_VALUE
         @repeat        = UNSET_VALUE
         @ssh_host      = UNSET_VALUE
         @ssh_port      = UNSET_VALUE
         @ssh_user      = UNSET_VALUE
+        @mem_cap_mb    = UNSET_VALUE
       end
-
-      #-------------------------------------------------------------------
-      # Internal methods.
-      #-------------------------------------------------------------------
-
-      # def merge(other)
-      #   super.tap do |result|
-      #     # TODO - do something sensible; current last config wins
-      #     result.local_folder = other.local_folder
-      #     result.remote_folder = other.remote_folder
-      #   end
-      # end
 
       def finalize!
         # The access keys default to nil
@@ -69,6 +64,7 @@ module VagrantPlugins
         @ssh_host     = '127.0.0.1' if @ssh_host     == UNSET_VALUE
         @ssh_port     = 2222        if @ssh_port     == UNSET_VALUE
         @ssh_user     = 'vagrant'   if @ssh_user     == UNSET_VALUE
+        @mem_cap_mb   = 200         if @mem_cap_mb   == UNSET_VALUE
 
         # Mark that we finalized
         @__finalized = true


### PR DESCRIPTION
You can now specify the memory usage limit in MB at which to restart Unison in the VM (because it leaks memory) as a config variable in the Vagrantfile. Default is 200MB.
