### PR TITLE
Fix ssh authorization issue.

### DIFF
--- a/lib/vagrant-unison2/ssh_command.rb
+++ b/lib/vagrant-unison2/ssh_command.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
           #{proxy_command}
           -o StrictHostKeyChecking=no
           -o UserKnownHostsFile=/dev/null
+          -o IdentitiesOnly=yes
           #{key_paths}
         ).compact.join(' ')
       end


### PR DESCRIPTION
This fixes an authorization issue that happens on `vagrant up` for me.

The deeper issue is that the current ssh options don't always match what vagrant expects (according to `vagrant ssh-config`). In the future, it would be good to set ssh options based on that instead of setting them statically in `lib/vagrant-unison2/ssh_command.rb`.
