### PR TITLE
Fix non-interactive mode for linux users

### DIFF
--- a/lib/vagrant-unison2/shell_command.rb
+++ b/lib/vagrant-unison2/shell_command.rb
@@ -29,6 +29,7 @@ module VagrantPlugins
           'unison',
           local_root_arg,
           remote_root_arg,
+          '-ui text',
           batch_arg,
           terse_arg,
           repeat_arg,


### PR DESCRIPTION
Enable non-interactive mode for linux users (where unison CLI automtically starts GUI and stalls)
